### PR TITLE
ignore-if-exists writers check for data existence before writing

### DIFF
--- a/src/pysparkbundle/csv/csv_write_ignore.py
+++ b/src/pysparkbundle/csv/csv_write_ignore.py
@@ -1,8 +1,8 @@
 from daipecore.decorator.DecoratedDecorator import DecoratedDecorator
-from pysparkbundle.write.PathWriterDecorator import PathWriterDecorator
+from pysparkbundle.write.PathWriterIgnoreDecorator import PathWriterIgnoreDecorator
 
 
 @DecoratedDecorator
-class csv_write_ignore(PathWriterDecorator):  # noqa: N801
+class csv_write_ignore(PathWriterIgnoreDecorator):  # noqa: N801
     _mode = "ignore"
     _writer_service = "pysparkbundle.csv.writer"

--- a/src/pysparkbundle/delta/delta_write_ignore.py
+++ b/src/pysparkbundle/delta/delta_write_ignore.py
@@ -1,8 +1,8 @@
 from daipecore.decorator.DecoratedDecorator import DecoratedDecorator
-from pysparkbundle.write.PathWriterDecorator import PathWriterDecorator
+from pysparkbundle.write.PathWriterIgnoreDecorator import PathWriterIgnoreDecorator
 
 
 @DecoratedDecorator
-class delta_write_ignore(PathWriterDecorator):  # noqa: N801
+class delta_write_ignore(PathWriterIgnoreDecorator):  # noqa: N801
     _mode = "ignore"
     _writer_service = "pysparkbundle.delta.writer"

--- a/src/pysparkbundle/json/json_write_ignore.py
+++ b/src/pysparkbundle/json/json_write_ignore.py
@@ -1,8 +1,8 @@
 from daipecore.decorator.DecoratedDecorator import DecoratedDecorator
-from pysparkbundle.write.PathWriterDecorator import PathWriterDecorator
+from pysparkbundle.write.PathWriterIgnoreDecorator import PathWriterIgnoreDecorator
 
 
 @DecoratedDecorator
-class json_write_ignore(PathWriterDecorator):  # noqa: N801
+class json_write_ignore(PathWriterIgnoreDecorator):  # noqa: N801
     _mode = "ignore"
     _writer_service = "pysparkbundle.json.writer"

--- a/src/pysparkbundle/parquet/parquet_write_ignore.py
+++ b/src/pysparkbundle/parquet/parquet_write_ignore.py
@@ -1,8 +1,8 @@
 from daipecore.decorator.DecoratedDecorator import DecoratedDecorator
-from pysparkbundle.write.PathWriterDecorator import PathWriterDecorator
+from pysparkbundle.write.PathWriterIgnoreDecorator import PathWriterIgnoreDecorator
 
 
 @DecoratedDecorator
-class parquet_write_ignore(PathWriterDecorator):  # noqa: N801
+class parquet_write_ignore(PathWriterIgnoreDecorator):  # noqa: N801
     _mode = "ignore"
     _writer_service = "pysparkbundle.parquet.writer"

--- a/src/pysparkbundle/write/PathWriterDecorator.py
+++ b/src/pysparkbundle/write/PathWriterDecorator.py
@@ -11,19 +11,19 @@ class PathWriterDecorator(OutputDecorator):  # noqa: N801
     _writer_service: str
 
     def __init__(self, path: str, partition_by: Union[str, list] = None, options: dict = None):
-        self.__path = path
+        self._path = path
 
         if partition_by is None:
-            self.__partition_by = []
+            self._partition_by = []
         elif isinstance(partition_by, str):
-            self.__partition_by = [partition_by]
+            self._partition_by = [partition_by]
         elif isinstance(partition_by, list):
-            self.__partition_by = partition_by
+            self._partition_by = partition_by
         else:
             raise Exception(f"Unexpected partition_by type: {type(partition_by)}")
 
-        self.__options = options
+        self._options = options
 
     def process_result(self, result: DataFrame, container: ContainerInterface):
         path_writer: PathWriter = container.get(self._writer_service)
-        path_writer.write(result, self.__path, self._mode, self.__partition_by, self.__options)
+        path_writer.write(result, self._path, self._mode, self._partition_by, self._options)

--- a/src/pysparkbundle/write/PathWriterIgnoreDecorator.py
+++ b/src/pysparkbundle/write/PathWriterIgnoreDecorator.py
@@ -1,0 +1,17 @@
+from logging import Logger
+from pyspark.sql import DataFrame
+from pysparkbundle.write.PathWriterDecorator import PathWriterDecorator
+from pysparkbundle.filesystem.FilesystemInterface import FilesystemInterface
+from injecta.container.ContainerInterface import ContainerInterface
+
+
+class PathWriterIgnoreDecorator(PathWriterDecorator):  # noqa: N801
+    def process_result(self, result: DataFrame, container: ContainerInterface):
+        filesystem: FilesystemInterface = container.get("pysparkbundle.filesystem")
+        logger: Logger = container.get("pysparkbundle.logger")
+
+        if filesystem.exists(self._path):
+            logger.info(f"Path {self._path} already exists, ignoring")
+            return
+
+        super().process_result(result, container)


### PR DESCRIPTION
To prevent "Unable to access" error when trying to write into read-only storage (PROD data mostly)